### PR TITLE
feat: RadioService & 라디오 스크립트 변환 기능 구현

### DIFF
--- a/Murmur.xcodeproj/project.pbxproj
+++ b/Murmur.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		14EBA6002E0FD87B00314128 /* StoryListCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14EBA5FF2E0FD87B00314128 /* StoryListCard.swift */; };
 		14EBA6022E0FDB8100314128 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14EBA6012E0FDB7C00314128 /* Date+Extensions.swift */; };
 		14EBA60B2E0FEB1100314128 /* MarqueeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14EBA60A2E0FEB0B00314128 /* MarqueeText.swift */; };
+		D1B9A9A72E11290800B7BAA0 /* UserStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B9A9A62E11290800B7BAA0 /* UserStory.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -64,7 +65,21 @@
 		14EBA5FF2E0FD87B00314128 /* StoryListCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryListCard.swift; sourceTree = "<group>"; };
 		14EBA6012E0FDB7C00314128 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		14EBA60A2E0FEB0B00314128 /* MarqueeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeText.swift; sourceTree = "<group>"; };
+		D1B9A9A62E11290800B7BAA0 /* UserStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		D1B9A9A02E11289700B7BAA0 /* Tests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		D1B9A9A22E1128B100B7BAA0 /* Services */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Services;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		14363FC12E0A98B10030A623 /* Frameworks */ = {
@@ -170,6 +185,7 @@
 		1488E4E82E0AF36100988B12 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				D1B9A9A62E11290800B7BAA0 /* UserStory.swift */,
 				14EBA5FC2E0FCB3400314128 /* Song.swift */,
 				14EBA5FA2E0FC9ED00314128 /* Story.swift */,
 				1488E4EF2E0AF9A200988B12 /* TempModel.swift */,
@@ -209,6 +225,8 @@
 		1488E4EC2E0AF48600988B12 /* Radio */ = {
 			isa = PBXGroup;
 			children = (
+				D1B9A9A22E1128B100B7BAA0 /* Services */,
+				D1B9A9A02E11289700B7BAA0 /* Tests */,
 				1488E4F32E0AF9B000988B12 /* TempRadio.swift */,
 			);
 			path = Radio;
@@ -245,6 +263,10 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				D1B9A9A02E11289700B7BAA0 /* Tests */,
+				D1B9A9A22E1128B100B7BAA0 /* Services */,
 			);
 			name = Murmur;
 			packageProductDependencies = (
@@ -317,6 +339,7 @@
 			files = (
 				14EBA5F52E0FB7E800314128 /* MurmurButton.swift in Sources */,
 				14363FDB2E0A9EB80030A623 /* HomeView.swift in Sources */,
+				D1B9A9A72E11290800B7BAA0 /* UserStory.swift in Sources */,
 				14EBA6002E0FD87B00314128 /* StoryListCard.swift in Sources */,
 				14EBA5F72E0FC3F200314128 /* TotalStoryListView.swift in Sources */,
 				14363FDC2E0A9EB80030A623 /* MurmurApp.swift in Sources */,

--- a/Murmur/Features/Radio/Services/RadioService.swift
+++ b/Murmur/Features/Radio/Services/RadioService.swift
@@ -1,0 +1,12 @@
+//
+//  RadioService.swift
+//  Murmur
+//
+//  Created by Muchan Kim on 6/29/25.
+//
+
+protocol RadioService {
+    func generateScript(from story: UserStory) -> RadioScript
+    // func convertTTS(from script: RadioScript) -> AudioData
+    // func generateSubtitles(from script: RadioScript) -> [Subtitle]
+}

--- a/Murmur/Features/Radio/Services/RadioServiceImpl.swift
+++ b/Murmur/Features/Radio/Services/RadioServiceImpl.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+final class RadioServiceImpl: RadioService {
+    
+    func generateScript(from story: UserStory) -> RadioScript {
+        let dateTimeInfo = getCurrentDateTimeInfo()
+        let emotionText = formatEmotions(story.emotionKeywords)
+        let fullScript = buildRadioScript(
+            dateTimeInfo: dateTimeInfo,
+            story: story,
+            emotionText: emotionText
+        )
+        
+        return RadioScript(fullScript: fullScript)
+    }
+}
+
+// MARK: - Private Helpers
+private extension RadioServiceImpl {
+    
+    // 날짜 문자열 처리
+    func getCurrentDateTimeInfo() -> (date: String, dayOfWeek: String, time: String) {
+        let currentDate = Date()
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        
+        dateFormatter.dateFormat = "yyyy년 M월 d일"
+        let formattedDate = dateFormatter.string(from: currentDate)
+        
+        dateFormatter.dateFormat = "EEEE"
+        let formattedDayOfWeek = dateFormatter.string(from: currentDate)
+        
+        dateFormatter.dateFormat = "a h시 mm분"
+        let formattedTime = dateFormatter.string(from: currentDate)
+        
+        return (formattedDate, formattedDayOfWeek, formattedTime)
+    }
+    
+    // 감정 문자열 처리
+    func formatEmotions(_ emotionKeywords: [String]) -> String {
+        guard !emotionKeywords.isEmpty else { 
+            return "복잡한 감정으로" 
+        }
+        
+        if emotionKeywords.count == 1 {
+            return "\(emotionKeywords[0])로"
+        } else {
+            let firstEmotion = emotionKeywords[0]
+            let secondEmotion = emotionKeywords[1]
+            return "\(firstEmotion) 그리고 \(secondEmotion)로"
+        }
+    }
+    
+    // 라디오 스크립트 생성
+    func buildRadioScript(
+        dateTimeInfo: (date: String, dayOfWeek: String, time: String),
+        story: UserStory,
+        emotionText: String
+    ) -> String {
+        return """
+        안녕하세요. Murmur 라디오 시작합니다.
+        
+        지금은 \(dateTimeInfo.date), \(dateTimeInfo.dayOfWeek), \(dateTimeInfo.time)입니다.
+        
+        오늘, 이런 사연이 도착했어요.
+        
+        "\(story.content)"
+        
+        오늘의 감정은 \(emotionText) 정리해볼 수 있을 것 같아요.
+        
+        그래서 준비한 곡은 \(story.recommendedSongAuthor)의 '\(story.recommendedSongTitle)'입니다.
+        
+        조용한 마음으로 감정을 따라가며 들어보세요.
+        
+        내일도 이 자리에서, 여러분의 이야기 기다릴게요.
+        
+        여기는 Murmur였습니다.
+        """
+    }
+} 

--- a/Murmur/Features/Radio/Tests/RadioTestMockData.swift
+++ b/Murmur/Features/Radio/Tests/RadioTestMockData.swift
@@ -1,0 +1,19 @@
+//
+//  Mock.swift
+//  Murmur
+//
+//  Created by Muchan Kim on 6/28/25.
+//
+
+import Foundation
+
+struct MockData {
+    static let sampleStory = UserStory(
+        createdAt: Date(),
+        content: "오늘은 웨이드가 나에게 심한 말을 했다. 근데 웨이드는 그걸 못 느끼는 것 같다. 또 나는 혼자 기분이 상한 상태다. 대화의 1원칙 여자친구한테 말하듯 하라는 건 벌써 잊은 것 같다. 참으로도 안타까운 현실이다.",
+        emotionKeywords: ["우울", "스트레스"],
+        recommendedSongAuthor: "P1nk!",
+        recommendedSongTitle: "True Love ft. Lily Allen"
+    )
+}
+

--- a/Murmur/Features/Radio/Tests/RadioTestView.swift
+++ b/Murmur/Features/Radio/Tests/RadioTestView.swift
@@ -1,0 +1,103 @@
+//
+//  TestView.swift
+//  Murmur
+//
+//  Created by Muchan Kim on 6/29/25.
+//
+
+import SwiftUI
+
+struct RadioTestView: View {
+    @StateObject private var viewModel = RadioTestViewModel()
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color.Gray900
+                    .ignoresSafeArea()
+                
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 24) {
+                        
+                        // UserStory 프로퍼티 표시
+                        VStack(alignment: .leading, spacing: 16) {
+                            Text("야생의 데이터")
+                                .font(.PretendardTitle3Bold)
+                                .foregroundColor(.KeyMint)
+                            
+                            VStack(alignment: .leading, spacing: 12) {
+                                PropertyRow(title: "ID", value: viewModel.currentStory.id.uuidString)
+                                PropertyRow(title: "생성일", value: viewModel.currentStory.createdAt.toFormattedString())
+                                PropertyRow(title: "감정 키워드", value: viewModel.currentStory.emotionKeywords.joined(separator: ", "))
+                                PropertyRow(title: "추천곡 아티스트", value: viewModel.currentStory.recommendedSongAuthor)
+                                PropertyRow(title: "추천곡 제목", value: viewModel.currentStory.recommendedSongTitle)
+                            }
+                            
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("사연 내용")
+                                    .font(.PretendardCalloutBold)
+                                    .foregroundColor(.Text03)
+                                
+                                Text(viewModel.currentStory.content)
+                                    .font(.PretendardBody)
+                                    .foregroundColor(.Text02)
+                                    .padding(16)
+                                    .background(Color.Gray800)
+                                    .cornerRadius(12)
+                            }
+                        }
+                        .padding(20)
+                        .background(Color.Gray800.opacity(0.5))
+                        .cornerRadius(16)
+                        
+                        // 생성된 라디오 스크립트 표시
+                        VStack(alignment: .leading, spacing: 16) {
+                            Text("생성된 라디오 스크립트")
+                                .font(.PretendardTitle3Bold)
+                                .foregroundColor(.PointMint)
+                            
+                            Text(viewModel.generatedScript.fullScript)
+                                .font(.PretendardBody)
+                                .foregroundColor(.Text02)
+                                .lineSpacing(4)
+                                .padding(20)
+                                .background(Color.Gray800)
+                                .cornerRadius(16)
+                        }
+                        .padding(20)
+                        .background(Color.Gray700.opacity(0.3))
+                        .cornerRadius(16)
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 16)
+                }
+            }
+            .navigationTitle("스크립트 확인 용 임시 뷰")
+            .navigationBarTitleDisplayMode(.large)
+            .preferredColorScheme(.dark)
+        }
+    }
+}
+
+struct PropertyRow: View {
+    let title: String
+    let value: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.PretendardCalloutBold)
+                .foregroundColor(.Text04)
+            
+            Text(value)
+                .font(.PretendardCallout)
+                .foregroundColor(.Text02)
+                .padding(.leading, 8)
+        }
+    }
+}
+
+#Preview {
+    RadioTestView()
+}
+

--- a/Murmur/Features/Radio/Tests/RadioTestViewModel.swift
+++ b/Murmur/Features/Radio/Tests/RadioTestViewModel.swift
@@ -1,0 +1,21 @@
+//
+//  TestViewModel.swift
+//  Murmur
+//
+//  Created by Muchan Kim on 6/29/25.
+//
+
+import Foundation
+
+final class RadioTestViewModel: ObservableObject {
+    @Published private(set) var currentStory: UserStory
+    @Published private(set) var generatedScript: RadioScript
+    
+    private let radioService: RadioService
+    
+    init(radioService: RadioService = RadioServiceImpl()) {
+        self.radioService = radioService
+        self.currentStory = MockData.sampleStory
+        self.generatedScript = radioService.generateScript(from: MockData.sampleStory)
+    }
+}

--- a/Murmur/Models/UserStory.swift
+++ b/Murmur/Models/UserStory.swift
@@ -1,0 +1,21 @@
+//
+//  UserStory.swift
+//  Murmur
+//
+//  Created by Muchan Kim on 6/28/25.
+//
+
+import Foundation
+
+struct UserStory: Identifiable {
+    let id = UUID()
+    let createdAt: Date
+    let content: String
+    let emotionKeywords: [String]
+    let recommendedSongAuthor: String
+    let recommendedSongTitle: String
+}
+
+struct RadioScript {
+    let fullScript: String
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #10


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] RadioService 인터페이스 구현
- [x] RadioService 구현체 - 스크립트 생성 기능 구현
- [x] MVVM 아키텍처 구현
- [x] 테스트 용 목데이터, 뷰, 뷰모델 구현

| <img src="https://github.com/user-attachments/assets/e7d9d276-e2a7-4086-9ce6-c6568c7b2a55" width="300"> | <img src="https://github.com/user-attachments/assets/d6d62d49-b697-409c-82ef-58fdae4b0d79" width="300"> |
|:---:|:---:|
| 테스트용1 | 테스트용2 |


### 핵심 기능
```swift    
func generateScript(from story: UserStory) -> RadioScript
```
- 사용자 사연을 입력받아 완성된 라디오 DJ 스크립트로 변환하는 메인 함수
- 사연 입력 -> 라디오 프롬프트 생성 -> TTS 변환 -> 자막 기능의 Flow 중 [라디오 프롬프트 생성] 단계

### 세부 구현
실시간 한국어 날짜/시간 변환
```swift    
func getCurrentDateTimeInfo() -> (date: String, dayOfWeek: String, time: String)
```
- 현재 시간을 한국어 형식으로 포맷팅 ("2025년 1월 29일, 수요일, 오후 3시 45분")

감정 키워드 문자열 보간
```swift    
func formatEmotions(_ emotionKeywords: [String]) -> String
```
- 감정 키워드 배열을 자연스러운 문장으로 변환 ("우울 그리고 스트레스로")

스크립트 조합
```swift    
func buildRadioScript(...) -> String
```
- 프롬프트 템플릿에 개인화 정보를 조합하여 최종 라디오 스크립트 생성

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- View 파일은 말그대로 '테스트용'입니다. 리뷰를 해주시지 않아도 됩니다.
- 의존성 흐름은 View -> ViewModel -> Service 레이어로 이어지고, 뷰모델과 서비스간 의존성은 추상화했습니다.
- ViewModel 같은 경우에는 해당 뷰 담당자가 제가 아니기에 일단 테스트로 넣었습니다. 활용하려면 프로퍼티 수정 필요합니다.
- 테스트를 하려면 MurmurApp.swift 코드의 `HomeView()`를 `RadioTestView()`로 바꿔주면 됩니다.