### PR TITLE
[Fix] DetailStoryView 스크롤바 위치 수정 + 각 페이지 accessibility label 적용

### DIFF
--- a/Murmur/Common/Components/CustomBackButton.swift
+++ b/Murmur/Common/Components/CustomBackButton.swift
@@ -16,6 +16,8 @@ struct CustomBackButton: ToolbarContent {
                 Image(systemName: "chevron.left")
                     .foregroundColor(Color.text01)
                     .font(.system(size: 17))
+                    .accessibilityLabel("뒤로가기")
+                    .accessibilityAddTraits(.isButton)
             }
         }
     }

--- a/Murmur/Features/Home/HomeView.swift
+++ b/Murmur/Features/Home/HomeView.swift
@@ -28,6 +28,7 @@ struct HomeView: View {
                     textColor: .text07,
                     bgColor: .keyMint
                 )
+                .accessibilityLabel("사연 신청하기 버튼")
                 .padding(.bottom, 12)
 
                 MurmurButton(
@@ -39,6 +40,7 @@ struct HomeView: View {
                     textColor: .text07,
                     bgColor: .PointPurple
                 )
+                .accessibilityLabel("사연 보기 버튼")
             }
             .padding(.horizontal, 48)
         }
@@ -59,6 +61,8 @@ struct OnAirSignView: View {
             .overlay(
                 OnAirText(isOn: isOn)
             )
+            .accessibilityLabel(isOn ? "ON AIR 불 켜짐" : "ON AIR 불 꺼짐")
+            .accessibilityHint(isOn ? "방송 중이에요. 오늘의 사연이 접수되었어요." : "방송 대기 중이에요. 오늘의 사연이 아직 없어요.")
     }
 }
 

--- a/Murmur/Features/Home/WriteView.swift
+++ b/Murmur/Features/Home/WriteView.swift
@@ -23,6 +23,8 @@ struct WriteView: View {
             VStack(alignment: .leading, spacing: 24) {
                 HStack(alignment: .top) {
                     Text("오늘의 사연을\n신청해보세요")
+                        .accessibilityLabel("오늘의 사연을 신청해보세요")
+                        .accessibilityAddTraits(.isHeader)
                         .font(.PretendardTitle1Bold)
                         .foregroundColor(Color.text01)
                         .kerning(0.38)
@@ -41,6 +43,8 @@ struct WriteView: View {
                             .frame(width: 20, height: 30)
                             .foregroundColor(Color.text01)
                     }
+                    .accessibilityLabel("음성으로 기록하기")
+                    .accessibilityAddTraits(.isButton)
                     .padding(.top, 28) // 텍스트 첫줄 높이에 맞춰 약간 내려줌
                 }
                 .padding(.top, 24)
@@ -64,6 +68,9 @@ struct WriteView: View {
                             .font(.PretendardBody)
                     }
                 }
+                .accessibilityLabel("사연 입력란")
+                .accessibilityHint("오늘 어떤 일이 있었나요? 하루를 떠올리며 입력해보세요.")
+                .accessibilityAddTraits(.allowsDirectInteraction)
                 .frame(minHeight: 140, maxHeight: 404) // 텍스트 입력 영역 높이 고정
                 .padding(.horizontal, 16)
 
@@ -84,6 +91,8 @@ struct WriteView: View {
                         navigationManager.push(to: .loading)
                     }
                 }
+                .accessibilityLabel("작성 완료")
+                .accessibilityAddTraits(.isButton)
                 .frame(maxWidth: .infinity, minHeight: 52)
                 .padding(.horizontal, 16)
                 Spacer()

--- a/Murmur/Features/Home/WriteView.swift
+++ b/Murmur/Features/Home/WriteView.swift
@@ -68,8 +68,8 @@ struct WriteView: View {
                             .font(.PretendardBody)
                     }
                 }
-                .accessibilityLabel("사연 입력란")
-                .accessibilityHint("오늘 어떤 일이 있었나요? 하루를 떠올리며 입력해보세요.")
+                .accessibilityLabel(isTextEditorFocused ? "사연 입력중" : "사연 입력란")
+                .accessibilityHint(isTextEditorFocused ? "300자까지 작성할 수 있어요." : "오늘 어떤 일이 있었나요? 하루를 떠올리며 입력해보세요.")
                 .accessibilityAddTraits(.allowsDirectInteraction)
                 .frame(minHeight: 140, maxHeight: 404) // 텍스트 입력 영역 높이 고정
                 .padding(.horizontal, 16)

--- a/Murmur/Features/Story/Components/DailyEmotionView.swift
+++ b/Murmur/Features/Story/Components/DailyEmotionView.swift
@@ -26,7 +26,7 @@ struct DailyEmotionView: View {
                 ForEach(0..<emotions.count, id: \.self) { index in
                     Text("\(emotions[index])")
                         .modifier(EmotionLabelModifier())
-                        .accessibilityLabel("추출된 감정")
+                        .accessibilityLabel("추출된 감정: \(emotions[index])")
                         .accessibilityAddTraits(.isStaticText)
                 }
             }

--- a/Murmur/Features/Story/Components/StoryListCard.swift
+++ b/Murmur/Features/Story/Components/StoryListCard.swift
@@ -14,6 +14,7 @@ struct StoryListCard: View {
         VStack {
             // 생성일
             Text(story.createdAt.toFormattedString())
+                .accessibilityLabel("\(story.createdAt.toFormattedString())")
                 .font(.PretendardTitle3Bold)
                 .foregroundStyle(.text07)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -25,6 +26,7 @@ struct StoryListCard: View {
                     Text(emotion)
                         .modifier(EmotionLabelModifier())
                         .padding(.trailing, 4) // 태그 간격 조정
+                        .accessibilityLabel("추출된 감정: \(emotion)")
                 }
 
                 Spacer()
@@ -33,6 +35,7 @@ struct StoryListCard: View {
 
             // 사연 내용
             Text(story.content)
+                .accessibilityLabel("사연 내용: \(story.content)")
                 .font(.PretendardBody)
                 .foregroundStyle(.text07)
                 .lineLimit(3) // 내용을 최대 3줄까지 표시
@@ -52,6 +55,7 @@ struct StoryListCard: View {
                     rightFade: 16,
                     startDelay: 1
                 )
+                .accessibilityLabel("추천곡 \(story.recommendedSongAuthor)의 \(story.recommendedSongTitle)")
 //                    Text("\(story.recommendedSongAuthor) -")
 //                        .font(.PretendardCallout)
 //                        .foregroundStyle(.text07)
@@ -61,7 +65,6 @@ struct StoryListCard: View {
 //                        .lineLimit(1)
                 Spacer()
             }
-
             .padding(12)
             .background(Color.gray200)
             .cornerRadius(50)

--- a/Murmur/Features/Story/Components/StoryMusicView.swift
+++ b/Murmur/Features/Story/Components/StoryMusicView.swift
@@ -40,7 +40,7 @@ struct StoryMusicView: View {
                             rightFade: 16,
                             startDelay: 1
                         )
-                        .accessibilityLabel("노래 제목")
+                        .accessibilityLabel(musicRecommendationVM.recommendedTrack?.title ?? "노래 제목")
                         .accessibilityAddTraits(.isStaticText)
 
                         MarqueeText(
@@ -51,7 +51,7 @@ struct StoryMusicView: View {
                             rightFade: 16,
                             startDelay: 1
                         )
-                        .accessibilityLabel("노래 가수")
+                        .accessibilityLabel(musicRecommendationVM.recommendedTrack?.artistName ?? "노래 가수")
                         .accessibilityAddTraits(.isStaticText)
                     }
                 }

--- a/Murmur/Features/Story/DetailStoryView.swift
+++ b/Murmur/Features/Story/DetailStoryView.swift
@@ -21,6 +21,7 @@ struct DetailStoryView: View {
             }
             .frame(maxWidth: .infinity)
         }
+        .navigationBarBackButtonHidden()
         .onDisappear {
             musicRecommendationVM.stopPlayback()
         }

--- a/Murmur/Features/Story/DetailStoryView.swift
+++ b/Murmur/Features/Story/DetailStoryView.swift
@@ -19,6 +19,7 @@ struct DetailStoryView: View {
                 }
                 DetailStoryButtonView()
             }
+            .frame(maxWidth: .infinity)
         }
         .onDisappear {
             musicRecommendationVM.stopPlayback()

--- a/Murmur/Features/Story/LoadingView.swift
+++ b/Murmur/Features/Story/LoadingView.swift
@@ -28,6 +28,7 @@ struct LoadingView: View {
                     .accessibilityLabel("사연에 딱 맞는 곡을 고르는 중이에요")
                     .accessibilityAddTraits(.isStaticText)
             }
+            .navigationBarBackButtonHidden()
             .onAppear {
                 Task {
                     // TODO: 예시) 검색어를 "Happy"로 지정, 실제로는 원하는 검색어로 변경

--- a/Murmur/Features/Story/TotalStoryListView.swift
+++ b/Murmur/Features/Story/TotalStoryListView.swift
@@ -53,9 +53,6 @@ struct TotalStoryListView: View {
                             ForEach(viewModel.stories) { story in
                                 StoryListCard(story: story)
                                     .padding(.bottom, 12)
-                                    .accessibilityLabel("\(story.createdAt.toFormattedString()), 추출된 감정: \(story.emotions), 사연 내용: \(story.content), 추천곡 \(story.recommendedSongAuthor)의 \(story.recommendedSongTitle)")
-                                    .accessibilityHint("무작위로 사연 하나가 열려요.")
-                                    .accessibilityAddTraits(.isButton)
                             }
                         }
                     }

--- a/Murmur/Features/Story/TotalStoryListView.swift
+++ b/Murmur/Features/Story/TotalStoryListView.swift
@@ -25,6 +25,9 @@ struct TotalStoryListView: View {
                             .padding(.vertical, 10)
                             .padding(.horizontal, 12)
                     }
+                    .accessibilityLabel("랜덤 사연 읽기")
+                    .accessibilityHint("무작위로 사연 하나가 열려요.")
+                    .accessibilityAddTraits(.isButton)
                     .background(Color.PointMint)
                     .cornerRadius(50)
                 }
@@ -50,6 +53,9 @@ struct TotalStoryListView: View {
                             ForEach(viewModel.stories) { story in
                                 StoryListCard(story: story)
                                     .padding(.bottom, 12)
+                                    .accessibilityLabel("\(story.createdAt.toFormattedString()), 추출된 감정: \(story.emotions), 사연 내용: \(story.content), 추천곡 \(story.recommendedSongAuthor)의 \(story.recommendedSongTitle)")
+                                    .accessibilityHint("무작위로 사연 하나가 열려요.")
+                                    .accessibilityAddTraits(.isButton)
                             }
                         }
                     }


### PR DESCRIPTION
### 📕 Issue Number

Close #37 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] DetailStoryView 스크롤바 위치 수정
- [x] 확인할 수 있는 모든 뷰에 accessibility label, trait, hint(존재하는 경우) 적용
- [x] 일부 뷰에서 백버튼이 나타나지 않아야 하는데 나타나는 경우 숨김 처리 적용


### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 각주로 코드 설명을 해야 할 정도의 특이점은 따로 없었습니다.
- DetailStoryView에서 frame 폭이 하위 뷰에 맞춰져 있어서 스크롤바 위치가 이상했었고, maxWidth를 .infinity로 적용해주는 방법으로 해결했습니다.
- 필요한 모든 요소들에 accessibility label, trait, hint를 적용했습니다. 실기기 테스트를 해보셔도 좋고, xcode - open devleoper tool - accessbility inspector로 확인하실 수 있습니다. 아래는 해당 기능으로 확인한 접근성 라벨의 스크린샷입니다.
<img width="1710" height="1107" alt="스크린샷 2025-08-10 오후 9 07 12" src="https://github.com/user-attachments/assets/f53e0b9e-90a4-4296-86a5-a00b18bc3bbf" />

<br/><br/>
