### PR TITLE
[Feat] 노래 재생/중지에 따라 아이콘 변화하도록 구현

### DIFF
--- a/Murmur/Features/Story/Components/StoryMusicView.swift
+++ b/Murmur/Features/Story/Components/StoryMusicView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct StoryMusicView: View {
     let musicRecommendationVM: MusicRecommendationViewModel
+    
+    @State var isPlaying: Bool = false
 
     static var screenWidth: CGFloat { UIScreen.main.bounds.width }
     static var widthSize: CGFloat { screenWidth * 0.9 }
@@ -59,12 +61,24 @@ struct StoryMusicView: View {
 
                 Button {
                     print("재생 버튼 눌림")
-                    musicRecommendationVM.playPreview()
+                    isPlaying.toggle()
+                    if isPlaying {
+                        musicRecommendationVM.playPreview()
+                    } else {
+                        musicRecommendationVM.stopPlayback()
+                    }
                 } label: {
-                    Image(systemName: "play.circle.fill")
-                        .resizable()
-                        .frame(width: StoryMusicView.screenWidth * 0.1, height: StoryMusicView.screenWidth * 0.1)
-                        .foregroundStyle(Color.text07)
+                    if isPlaying {
+                        Image(systemName: "pause.circle.fill")
+                            .resizable()
+                            .frame(width: StoryMusicView.screenWidth * 0.1, height: StoryMusicView.screenWidth * 0.1)
+                            .foregroundStyle(Color.text07)
+                    } else {
+                        Image(systemName: "play.circle.fill")
+                            .resizable()
+                            .frame(width: StoryMusicView.screenWidth * 0.1, height: StoryMusicView.screenWidth * 0.1)
+                            .foregroundStyle(Color.text07)
+                    }
                 }
             }
             .padding(12)


### PR DESCRIPTION
### 📕 Issue Number

Close #46 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 노래 재생 누름 -> 정지 버튼으로 변화
- [x] 정지 버튼 누름 -> 재생 버튼으로 변화


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 각주로 따로 설명을 달아야 할 만큼 특이점은 없었습니다.
- isPlaying으로 재생중/중지중인 경우에 따라 아이콘이 변경되고, 음악이 재생되고 멈추도록 구현하였습니다.

https://github.com/user-attachments/assets/bba4a0e7-dd94-4426-bfbc-b0d1bf76fc85



<br/><br/>
