### PR TITLE
[Chore] 알럿창 패딩값 수정 + 커서와 플레이스홀더 크기 수정

### DIFF
--- a/Murmur/Features/Home/FailAlertView.swift
+++ b/Murmur/Features/Home/FailAlertView.swift
@@ -19,7 +19,7 @@ struct FailAlertView: View {
                 Color.gray900.opacity(0.4)
                     .edgesIgnoringSafeArea(.all)
                 
-                VStack(spacing: 12) {
+                VStack {
                     
                     // 알림 아이콘
                     Image("Warning")
@@ -27,7 +27,7 @@ struct FailAlertView: View {
                         .frame(width: 60, height: 60,alignment: .top)
                         .foregroundColor(Color.PointMint)
                         .accessibilityLabel("경고 사이렌")
-                        .padding(.top,12)
+                        .padding(.top, 12)
                     
                     // 메시지
                     Text("아직 사연이\n작성되지 않았어요")
@@ -35,6 +35,7 @@ struct FailAlertView: View {
                         .foregroundColor(Color.text06)
                         .font(.PretendardTitle3SemiBold)
                         .accessibilityLabel("아직 사연이\n작성되지 않았어요")
+                        .padding(.top, 8)
                     
                     // 확인 버튼
                     Button(action: {
@@ -51,7 +52,8 @@ struct FailAlertView: View {
                             .foregroundColor(Color.text07)
                             .cornerRadius(10)
                             .accessibilityLabel("확인")
-                            .padding(.vertical, 12)
+                            .padding(.top, 4)
+                            .padding(.bottom, 12)
                     }
                 }
                 .padding(.horizontal, 11)

--- a/Murmur/Features/Home/WriteView.swift
+++ b/Murmur/Features/Home/WriteView.swift
@@ -9,13 +9,16 @@ struct WriteView: View {
     @StateObject private var audioRecorder = AudioRecorder()
     @State private var userInput: String = ""
     @State private var keyboardHeight: CGFloat = 0
-    private let placeholder = "오늘 어떤 일이 있었나요?\n하루를 떠올리며 입력해보세요"
+    private let placeholder1 = "오늘 어떤 일이 있었나요?"
+    private let placeholder2 = "하루를 떠올리며 입력해보세요"
     @FocusState private var isTextEditorFocused: Bool
     @EnvironmentObject private var navigationManager: NavigationManager
 
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
-        _viewModel = StateObject(wrappedValue: WriteViewModel(modelContext: modelContext))
+        _viewModel = StateObject(
+            wrappedValue: WriteViewModel(modelContext: modelContext)
+        )
     }
 
     var body: some View {
@@ -62,6 +65,7 @@ struct WriteView: View {
                     RoundedRectangle(cornerRadius: 15)
                         .fill(Color.text01)
                     TextEditor(text: $userInput)
+                        .font(.PretendardBody)
                         .padding(16)
                         .background(Color.clear)
                         .cornerRadius(15)
@@ -69,14 +73,19 @@ struct WriteView: View {
                         .scrollContentBackground(.hidden)
                         .focused($isTextEditorFocused)
                     if userInput.isEmpty {
-                        Text(placeholder)
-                            .foregroundColor(Color.Gray700)
-                            .padding(20)
-                            .font(.PretendardBody)
+                        VStack {
+                            Text(placeholder1) + Text("\n") + Text(placeholder2)
+                        }
+                        .foregroundColor(Color.Gray700)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 22)
+                        .font(.PretendardBody)
                     }
                 }
                 .accessibilityLabel(isTextEditorFocused ? "사연 입력중" : "사연 입력란")
-                .accessibilityHint(isTextEditorFocused ? "300자까지 작성할 수 있어요." : "오늘 어떤 일이 있었나요? 하루를 떠올리며 입력해보세요.")
+                .accessibilityHint(
+                    isTextEditorFocused ? "300자까지 작성할 수 있어요." : "오늘 어떤 일이 있었나요? 하루를 떠올리며 입력해보세요."
+                )
                 .accessibilityAddTraits(.allowsDirectInteraction)
                 .frame(minHeight: 140, maxHeight: 404) // 텍스트 입력 영역 높이 고정
                 .padding(.horizontal, 16)
@@ -89,7 +98,8 @@ struct WriteView: View {
                     foregroundColor: Color.Gray900,
                     cornerRadius: 15
                 ) {
-                    if userInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    if userInput
+                        .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         viewModel.showFailAlert = true
                     } else {
                         // 사연 작성 완료 처리
@@ -131,12 +141,18 @@ struct WriteView: View {
             audioRecorder.userInputBinding = $userInput
         }
         // 키보드 높이 감지 및 동적 반영
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+        .onReceive(
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillShowNotification)
+        ) { notification in
             if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
                 keyboardHeight = keyboardFrame.height
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+        .onReceive(
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillHideNotification)
+        ) { _ in
             keyboardHeight = 0
         }
     }


### PR DESCRIPTION
### 📕 Issue Number

Close #49 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 사연 미작성시 노출되는 알럿창의 여백을 디자인과 일치하게 수정
- [x] 커서 크기와 맞도록 플레이스홀더 줄바꿈 방식 + 위치 수정


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 각주로 설명할 정도로 복잡한 특이점은 없었습니다.
- FailAlertView에서 각 컴포넌트별로 여백값이 디자인과 달랐던 부분을 일치시켰습니다.
- 커서와 placeholder의 크기가 달랐던 부분을 조정했습니다. 커서의 크기나 플레이스홀더의 줄간격을 바꾸는 것은 너무 복잡하고 불필요하게 공수가 커져서, 줄바꿈 방식을 바꾸었습니다. 추가적으로 커서의 중앙에 플레이스홀더 첫 줄이 중앙 정렬될 수 있도록 위치를 수정했습니다. 
- 아래 영상에서 수정된 모습을 확인할 수 있습니다.

https://github.com/user-attachments/assets/7d7ebe6b-8a9f-46a0-8128-dc5ad45b6eee




<br/><br/>
