### PR TITLE
[Feat] RadioView 음악 미리듣기 추가하기

### DIFF
--- a/Murmur/Features/Radio/RadioView.swift
+++ b/Murmur/Features/Radio/RadioView.swift
@@ -8,8 +8,16 @@
 import SwiftUI
 
 struct RadioView: View {
-    @StateObject private var viewModel = RadioViewModel()
+    @StateObject private var viewModel: RadioViewModel
     @EnvironmentObject private var navigationManager: NavigationManager
+    @EnvironmentObject private var musicRecommendationVM: MusicRecommendationViewModel
+    
+    init() {
+        // 기본 MusicRecommendationViewModel로 초기화
+        self._viewModel = StateObject(wrappedValue: RadioViewModel(
+            musicRecommendationViewModel: MusicRecommendationViewModel()
+        ))
+    }
 
     var body: some View {
         ZStack {
@@ -25,19 +33,6 @@ struct RadioView: View {
                 RadioSubtitleView(subtitle: viewModel.currentSubtitle)
 
                 Spacer()
-
-                // 작성 완료 버튼
-                Button {
-                    navigationManager.popToRoot()
-                } label: {
-                    Text("홈으로 이동")
-                        .font(.PretendardBodySemiBold)
-                        .foregroundColor(Color.Gray900)
-                        .frame(maxWidth: .infinity, minHeight: 52)
-                        .background(Color.PointMint)
-                        .cornerRadius(15)
-                }
-                .padding(.horizontal, 32)
             }
         }
         .navigationBarBackButtonHidden()
@@ -48,10 +43,21 @@ struct RadioView: View {
             }
         }
         .onAppear {
+            print(" RadioView onAppear")
+            print("🔍 musicRecommendationVM.recommendedTrack: \(String(describing: musicRecommendationVM.recommendedTrack))")
+            
+            // EnvironmentObject에서 전달받은 MusicRecommendationViewModel 설정
+            viewModel.setMusicViewModel(musicRecommendationVM)
             viewModel.startPlaying()
         }
         .onDisappear {
             viewModel.stopPlaying()
+        }
+        .onChange(of: viewModel.shouldNavigateToHome) { shouldNavigate in
+            if shouldNavigate {
+                print(" View에서 홈 이동 신호 감지! 홈으로 이동")
+                navigationManager.popToRoot()
+            }
         }
     }
 }
@@ -60,5 +66,6 @@ struct RadioView: View {
     NavigationView {
         RadioView()
             .environmentObject(NavigationManager())
+            .environmentObject(MusicRecommendationViewModel())
     }
 }

--- a/Murmur/Features/Radio/RadioViewModel.swift
+++ b/Murmur/Features/Radio/RadioViewModel.swift
@@ -13,15 +13,29 @@ final class RadioViewModel: ObservableObject {
     @Published var generatedScript: RadioScript?
     @Published var isPlaying: Bool = false
     @Published var currentSubtitle: String = ""
+    @Published var isMusicPlaying: Bool = false
+    @Published var shouldNavigateToHome: Bool = false
 
     private let sessionManager: RadioSessionManager
+    private var musicRecommendationViewModel: MusicRecommendationViewModel
     private var subtitleSegments: [SubtitleSegment] = []
     
-    init(sessionManager: RadioSessionManager = RadioSessionManager()) {
+    init(sessionManager: RadioSessionManager = RadioSessionManager(),
+         musicRecommendationViewModel: MusicRecommendationViewModel) {
         self.sessionManager = sessionManager
+        self.musicRecommendationViewModel = musicRecommendationViewModel
         self.currentStory = MockData.sampleStory
         
         loadInitialData()
+    }
+    
+    func setMusicViewModel(_ viewModel: MusicRecommendationViewModel) {
+        print("🔧 setMusicViewModel 호출됨")
+        print("🔧 전달받은 recommendedTrack: \(String(describing: viewModel.recommendedTrack))")
+        
+        self.musicRecommendationViewModel = viewModel
+        
+        print("🔧 설정 완료: \(String(describing: self.musicRecommendationViewModel.recommendedTrack))")
     }
     
     func startPlaying() {
@@ -38,18 +52,91 @@ final class RadioViewModel: ObservableObject {
             },
             complete: { [weak self] in
                 DispatchQueue.main.async {
-                    self?.isPlaying = false
+                    // TTS 완료 후에도 isPlaying을 true로 유지
                     self?.currentSubtitle = ""
+                }
+            },
+            onMusicPlay: { [weak self] in
+                DispatchQueue.main.async {
+                    // TTS 완료 후 추천된 음악 재생
+                    self?.playRecommendedMusic()
                 }
             }
         )
     }
     
     func stopPlaying() {
+        print("🛑 RadioViewModel stopPlaying 호출됨")
+        
         sessionManager.stop()
+        musicRecommendationViewModel.stopPlayback()
         
         isPlaying = false
+        isMusicPlaying = false
         currentSubtitle = ""
+        
+        print("🛑 모든 재생 상태 정지 완료")
+    }
+    
+    // 추천된 음악 재생 메서드
+    private func playRecommendedMusic() {
+        print("🔍 playRecommendedMusic 호출됨")
+        print("🔍 recommendedTrack: \(String(describing: musicRecommendationViewModel.recommendedTrack))")
+        
+        // 이미 추천된 음악이 있다면 미리듣기 재생
+        if let track = musicRecommendationViewModel.recommendedTrack {
+            
+            // 음악 정보를 자막에 표시
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                
+                let musicInfo = "\(track.title) - \(track.artistName)"
+                self.currentSubtitle = musicInfo
+                self.isMusicPlaying = true
+                
+                print("📝 자막에 표시: \(musicInfo)")
+                print(" currentSubtitle 상태: \(self.currentSubtitle)")
+                
+                // UI 강제 업데이트를 위한 추가 설정
+                self.objectWillChange.send()
+            }
+            
+            musicRecommendationViewModel.playPreview()
+            
+            // 음악 재생 완료 후 홈으로 이동 신호 전송
+            scheduleMusicCompletion()
+        } else {
+            print("⚠️ 추천된 음악이 없습니다")
+            // 음악이 없어도 홈으로 이동 신호 전송
+            scheduleMusicCompletion()
+        }
+    }
+    
+    // 음악 완료 후 홈으로 이동 신호 전송
+    private func scheduleMusicCompletion() {
+        // 30초 미리듣기 + 1초 여유시간 후 완료 처리
+        DispatchQueue.main.asyncAfter(deadline: .now() + 31.0) { [weak self] in
+            DispatchQueue.main.async {
+                self?.finishMusicAndSendHomeSignal()
+            }
+        }
+    }
+    
+    // 음악 완료 처리 및 홈 이동 신호 전송
+    private func finishMusicAndSendHomeSignal() {
+        print(" 음악 재생 완료! ON AIR 끄고 홈 이동 신호 전송")
+        
+        // ON AIR 끄기
+        isPlaying = false
+        isMusicPlaying = false
+        currentSubtitle = ""
+        
+        // 1.0초 후 홈 이동 신호 전송
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            DispatchQueue.main.async {
+                self?.shouldNavigateToHome = true
+            }
+        }
     }
         
     private func loadInitialData() {

--- a/Murmur/Features/Radio/Services/RadioSessionManager.swift
+++ b/Murmur/Features/Radio/Services/RadioSessionManager.swift
@@ -19,6 +19,7 @@ class RadioSessionManager {
     
     private var onSubtitleChangeCallback: ((String) -> Void)?
     private var onCompleteCallback: (() -> Void)?
+    private var onMusicPlayCallback: (() -> Void)?
     
     private var subtitleTimer: Timer?
     
@@ -40,7 +41,10 @@ class RadioSessionManager {
         return subtitleService.generateSegments(from: script)
     }
     
-    func play(segments: [SubtitleSegment], onSubtitleChange: @escaping (String) -> Void, complete: @escaping () -> Void) {
+    func play(segments: [SubtitleSegment],
+              onSubtitleChange: @escaping (String) -> Void,
+              complete: @escaping () -> Void,
+              onMusicPlay: @escaping () -> Void) {
         if isCurrentlyPlaying {
             stop()
         }
@@ -50,6 +54,7 @@ class RadioSessionManager {
         self.isCurrentlyPlaying = true
         self.onSubtitleChangeCallback = onSubtitleChange
         self.onCompleteCallback = complete
+        self.onMusicPlayCallback = onMusicPlay
         
         playCurrentSegment()
     }
@@ -67,6 +72,7 @@ class RadioSessionManager {
         
         onSubtitleChangeCallback = nil
         onCompleteCallback = nil
+        onMusicPlayCallback = nil
     }
     
     func getState() -> (isPlaying: Bool, currentSubtitle: String) {
@@ -79,8 +85,15 @@ class RadioSessionManager {
         guard currentIndex < segments.count else {
             isCurrentlyPlaying = false
             let completeCallback = onCompleteCallback
+            let musicPlayCallback = onMusicPlayCallback
+            
             onCompleteCallback = nil
             onSubtitleChangeCallback = nil
+            onMusicPlayCallback = nil
+            
+            // TTS 완료 시점에 음악 재생 콜백 호출
+            musicPlayCallback?()
+            
             completeCallback?()
             return
         }

--- a/Murmur/Features/Story/MusicRecommendationViewModel.swift
+++ b/Murmur/Features/Story/MusicRecommendationViewModel.swift
@@ -14,8 +14,10 @@ class MusicRecommendationViewModel: ObservableObject {
     @Published var foundPlaylist: Playlist?
     @Published var recommendedTrack: MusicItemCollection<Track>.Element?
     @Published var playerItem: AVPlayerItem?
+    @Published var isMusicPlaying: Bool = false  // 음악 재생 상태 추가
 
     private let player: AVPlayer = .init()
+    private var musicCompletionTimer: Timer?  // 음악 완료 타이머 추가
 
     // 1️⃣ MusicKit 권한을 요청하는 비동기 함수
     @MainActor
@@ -89,11 +91,19 @@ class MusicRecommendationViewModel: ObservableObject {
                 print("미리듣기를 지원하지 않는 곡이거나 URL이 없습니다.")
                 return
             }
+            
             await MainActor.run {
                 playerItem = AVPlayerItem(url: url)
                 player.replaceCurrentItem(with: playerItem)
                 player.play()
+                
+                // 음악 재생 상태 시작
+                isMusicPlaying = true
+                
+                // 음악 완료 타이머 설정 (30초 미리듣기 + 여유시간)
+                startMusicCompletionTimer()
             }
+            
             print("\(String(describing: recommendedTrack?.title)) 30초 미리듣기를 재생합니다.")
         }
     }
@@ -102,7 +112,38 @@ class MusicRecommendationViewModel: ObservableObject {
     func stopPlayback() {
         player.pause()
         player.replaceCurrentItem(with: nil)
+        
+        // 음악 재생 상태 정지
+        isMusicPlaying = false
+        
+        // 타이머 정리
+        stopMusicCompletionTimer()
+        
         print("플레이어를 정지했습니다.")
     }
+    
+    // 5️⃣ 음악 완료 타이머 시작
+    private func startMusicCompletionTimer() {
+        // 기존 타이머 정리
+        stopMusicCompletionTimer()
+        
+        // 30초 미리듣기 + 1초 여유시간 후 완료 처리
+        musicCompletionTimer = Timer.scheduledTimer(withTimeInterval: 31.0, repeats: false) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.onMusicCompleted()
+            }
+        }
+    }
+    
+    // 6️⃣ 음악 완료 타이머 정지
+    private func stopMusicCompletionTimer() {
+        musicCompletionTimer?.invalidate()
+        musicCompletionTimer = nil
+    }
+    
+    // 7️⃣ 음악 재생 완료 처리
+    private func onMusicCompleted() {
+        isMusicPlaying = false
+        print("�� 음악 재생 완료!")
+    }
 }
-


### PR DESCRIPTION
### 📕 Issue Number

Close #47 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

TTS 이후 음악 재생 기능 추가, 이에따른 자막에 노래 제목 - 가수 UI 구현 작업을 했습니다.

주요 수정 파일
RadioViewModel.swift - TTS 완료 후 음악 자동 재생 및 자막 표시
RadioView.swift - DetailStoryView 음악 정보 연동 및 자동 홈 이동
RadioSessionManager.swift - TTS 완료 후 음악 재생 콜백 시스템
MusicRecommendationViewModel.swift - 음악 재생 상태 추적 및 완료 감지

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

빠른 테스트를 위해 스크립트를 줄여서 하시는 걸 권장합니다. 
```swift
    func buildRadioScript(
        dateTimeInfo: (date: String, dayOfWeek: String, time: String),
        story: Story,
        emotionText: String
    ) -> String {
        return """
        안녕하세요. Murmur 라디오 시작합니다.

        """
    }
```


<br/><br/>
