### PR TITLE
[Fix] 음악 미리듣기 끝나면 재생 아이콘으로 돌아오도록 수정

### DIFF
--- a/Murmur/Features/Story/Components/StoryMusicView.swift
+++ b/Murmur/Features/Story/Components/StoryMusicView.swift
@@ -65,7 +65,7 @@ struct StoryMusicView: View {
                     }
                 } label: {
                     if musicRecommendationVM.isMusicPlaying {
-                        Image(systemName: "pause.circle.fill")
+                        Image(systemName: "stop.circle.fill")
                             .resizable()
                             .frame(width: StoryMusicView.screenWidth * 0.1, height: StoryMusicView.screenWidth * 0.1)
                             .foregroundStyle(Color.text07)

--- a/Murmur/Features/Story/Components/StoryMusicView.swift
+++ b/Murmur/Features/Story/Components/StoryMusicView.swift
@@ -9,10 +9,7 @@ import MusicKit
 import SwiftUI
 
 struct StoryMusicView: View {
-    let musicRecommendationVM: MusicRecommendationViewModel
-    
-    @State var isPlaying: Bool = false
-
+    @ObservedObject var musicRecommendationVM: MusicRecommendationViewModel
     static var screenWidth: CGFloat { UIScreen.main.bounds.width }
     static var widthSize: CGFloat { screenWidth * 0.9 }
 
@@ -61,14 +58,13 @@ struct StoryMusicView: View {
 
                 Button {
                     print("재생 버튼 눌림")
-                    isPlaying.toggle()
-                    if isPlaying {
-                        musicRecommendationVM.playPreview()
-                    } else {
+                    if musicRecommendationVM.isMusicPlaying {
                         musicRecommendationVM.stopPlayback()
+                    } else {
+                        musicRecommendationVM.playPreview()
                     }
                 } label: {
-                    if isPlaying {
+                    if musicRecommendationVM.isMusicPlaying {
                         Image(systemName: "pause.circle.fill")
                             .resizable()
                             .frame(width: StoryMusicView.screenWidth * 0.1, height: StoryMusicView.screenWidth * 0.1)


### PR DESCRIPTION
### 📕 Issue Number

Close #55 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 음악 미리듣기가 끝나면 play.circle.fill로 버튼 라벨이 돌아오도록 수정
- [x] 음악 미리듣기는 일시정지가 없고 중지 개념에 가까우므로 기존의 pause.circle.fill을 stop.circle.fill로 수정


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이사항은 따로 없습니다. 아래 영상 학인하시면 잘 작동하는 거 볼 수 있습니다~!

https://github.com/user-attachments/assets/2757e320-c715-40aa-b080-954a205267ea



<br/><br/>
